### PR TITLE
Remove 3 ASCII upper-case letter restrictio

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -27,3 +27,8 @@ The Joda team
 * `mvn clean deploy -Doss.repo -Dgpg.passphrase=""`
 * Release project in [Nexus](https://oss.sonatype.org)
 * Website will be built and released by Travis
+
+### Fork Release process
+* Update version (pom.xml, README.md, index.md, changes.xml)
+* `mvn clean install`
+** This creates a `joda-money-{version}.jar` in `target` folder

--- a/src/main/java/org/joda/money/CurrencyUnit.java
+++ b/src/main/java/org/joda/money/CurrencyUnit.java
@@ -192,9 +192,6 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>, Serializabl
         if (currencyCode.length() != 3) {
             throw new IllegalArgumentException("Invalid string code, must be length 3");
         }
-        if (CODE.matcher(currencyCode).matches() == false) {
-            throw new IllegalArgumentException("Invalid string code, must be ASCII upper-case letters");
-        }
         if (numericCurrencyCode < -1 || numericCurrencyCode > 999) {
             throw new IllegalArgumentException("Invalid numeric code");
         }

--- a/src/test/java/org/joda/money/TestCurrencyUnit.java
+++ b/src/test/java/org/joda/money/TestCurrencyUnit.java
@@ -72,6 +72,7 @@ public class TestCurrencyUnit {
         CurrencyUnit.registerCurrency("", 991, 2, Arrays.asList("TS"));
     }
 
+/*
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void test_registeredCurrency_invalidStringCode_1letter() {
         CurrencyUnit.registerCurrency("A", 991, 2, Arrays.asList("TS"));
@@ -101,7 +102,8 @@ public class TestCurrencyUnit {
     public void test_registeredCurrency_invalidStringCode_dash() {
         CurrencyUnit.registerCurrency("A-", 991, 2, Arrays.asList("TS"));
     }
-
+*/
+    
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void test_registeredCurrency_invalidNumericCode_small() {
         CurrencyUnit.registerCurrency("TST", -2, 2, Arrays.asList("TS"));


### PR DESCRIPTION
- In order for `B2X` to be recognized as a valid `CurrencyUnit`, it needs to be registered when app loads. One issue though is that `CurrencyUnit` from `joda-money` has a strict requirement such that the currency code being registered has to be three upper-case ASCII letters, which means that `B2X` is considered invalid. To get around this (temporarily at least for the B2X release), remove the regex restriction. See: https://github.cbhq.net/engineering/coinbase-android/pull/507