### PR TITLE
Remove tests that check for regexp of currency

### DIFF
--- a/src/test/java/org/joda/money/TestCurrencyUnit.java
+++ b/src/test/java/org/joda/money/TestCurrencyUnit.java
@@ -67,10 +67,13 @@ public class TestCurrencyUnit {
         CurrencyUnit.registerCurrency(null, 991, 2, Arrays.asList("TS"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void test_registeredCurrency_invalidStringCode_empty() {
-        CurrencyUnit.registerCurrency("", 991, 2, Arrays.asList("TS"));
-    }
+    /**
+     * Coinbase removed the reg ex restriction
+     * @Test(expectedExceptions = IllegalArgumentException.class)
+     * public void test_registeredCurrency_invalidStringCode_empty() {
+     *     CurrencyUnit.registerCurrency("", 991, 2, Arrays.asList("TS"));
+     * }
+     */
 
 /*
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -121,7 +124,7 @@ public class TestCurrencyUnit {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void test_registeredCurrency_invalidDP_big() {
-        CurrencyUnit.registerCurrency("TST", 991, 10, Arrays.asList("TS"));
+        CurrencyUnit.registerCurrency("TST", 991, 31, Arrays.asList("TS"));
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/org/joda/money/format/TestMoneyFormatterBuilder.java
+++ b/src/test/java/org/joda/money/format/TestMoneyFormatterBuilder.java
@@ -149,16 +149,19 @@ public class TestMoneyFormatterBuilder {
         assertEquals(parsed.getCurrency(), null);
     }
 
-    public void test_appendCurrencyNumeric3Code_parse_badCurrency() {
-        iBuilder.appendCurrencyNumeric3Code();
-        MoneyFormatter test = iBuilder.toFormatter();
-        MoneyParseContext  parsed = test.parse("991A", 0);
-        assertEquals(parsed.isError(), true);
-        assertEquals(parsed.getIndex(), 0);
-        assertEquals(parsed.getErrorIndex(), 0);
-        assertEquals(parsed.getAmount(), null);
-        assertEquals(parsed.getCurrency(), null);
-    }
+    /**
+     * Coinbase removed the restriction for numeric code and length in currency
+     * public void test_appendCurrencyNumeric3Code_parse_badCurrency() {
+     *     iBuilder.appendCurrencyNumeric3Code();
+     *     MoneyFormatter test = iBuilder.toFormatter();
+     *     MoneyParseContext  parsed = test.parse("991A", 0);
+     *     assertEquals(parsed.isError(), true);
+     *     assertEquals(parsed.getIndex(), 0);
+     *     assertEquals(parsed.getErrorIndex(), 0);
+     *     assertEquals(parsed.getAmount(), null);
+     *     assertEquals(parsed.getCurrency(), null);
+     * }
+     */
 
     public void test_appendCurrencyNumeric3Code_parse_empty() {
         iBuilder.appendCurrencyNumeric3Code();
@@ -234,16 +237,19 @@ public class TestMoneyFormatterBuilder {
         assertEquals(parsed.getCurrency(), null);
     }
 
-    public void test_appendCurrencyNumericCode_parse_badCurrency() {
-        iBuilder.appendCurrencyNumericCode();
-        MoneyFormatter test = iBuilder.toFormatter();
-        MoneyParseContext  parsed = test.parse("991A", 0);
-        assertEquals(parsed.isError(), true);
-        assertEquals(parsed.getIndex(), 0);
-        assertEquals(parsed.getErrorIndex(), 0);
-        assertEquals(parsed.getAmount(), null);
-        assertEquals(parsed.getCurrency(), null);
-    }
+    /**
+     * Coinbase removed the restriction for numeric code and length in currency
+     * public void test_appendCurrencyNumericCode_parse_badCurrency() {
+     *     iBuilder.appendCurrencyNumericCode();
+     *     MoneyFormatter test = iBuilder.toFormatter();
+     *     MoneyParseContext  parsed = test.parse("991A", 0);
+     *     assertEquals(parsed.isError(), true);
+     *     assertEquals(parsed.getIndex(), 0);
+     *     assertEquals(parsed.getErrorIndex(), 0);
+     *     assertEquals(parsed.getAmount(), null);
+     *     assertEquals(parsed.getCurrency(), null);
+     * }
+     */
 
     public void test_appendCurrencyNumericCode_parse_empty() {
         iBuilder.appendCurrencyNumericCode();


### PR DESCRIPTION
Remove tests that assert currency name length
Fix tests that assert currency decimal places <= 9 and change to <= 30